### PR TITLE
fix: print "func" instead of full function body in plugin state view

### DIFF
--- a/example/empty-plugin.js
+++ b/example/empty-plugin.js
@@ -1,0 +1,22 @@
+import { Plugin, PluginKey } from "prosemirror-state";
+
+function createPluginState() {
+  return {
+    doSomething() {}
+  };
+}
+
+const key = new PluginKey("empty-plugin");
+const plugin = new Plugin({
+  key,
+  state: {
+    init() {
+      return createPluginState();
+    },
+    apply(tr, pluginState) {
+      return pluginState;
+    }
+  }
+});
+
+export default plugin;

--- a/example/index.js
+++ b/example/index.js
@@ -6,11 +6,13 @@ import { EditorView } from "prosemirror-view";
 import { schema } from "prosemirror-schema-basic";
 import { exampleSetup } from "prosemirror-example-setup";
 
+import plugin from "./empty-plugin";
+
+const plugins = exampleSetup({ schema });
+plugins.push(plugin);
+
 const view = new EditorView(document.querySelector("#app"), {
-  state: EditorState.create({
-    schema,
-    plugins: exampleSetup({ schema })
-  })
+  state: EditorState.create({ schema, plugins })
 });
 
 applyDevTools(view);

--- a/src/tabs/plugins.js
+++ b/src/tabs/plugins.js
@@ -3,9 +3,26 @@ import { connect } from "cerebral/react";
 import { state, signal } from "cerebral/tags";
 
 import { InfoPanel } from "../components/info-panel";
+import { Heading } from "./../components/heading";
 import JSONTree from "../components/json-tree";
 import { List } from "../components/list";
 import { SplitView, SplitViewCol } from "../components/split-view";
+
+export function valueRenderer(raw, ...rest) {
+  if (typeof rest[0] === "function") {
+    return "func";
+  }
+  return raw;
+}
+
+export function PluginState(props) {
+  return (
+    <div>
+      <Heading>Plugin State</Heading>
+      <JSONTree data={props.pluginState} valueRenderer={valueRenderer} />
+    </div>
+  );
+}
 
 export default connect(
   {
@@ -17,6 +34,7 @@ export default connect(
     const { plugins } = state;
     const selectedPlugin = plugins[selected];
     const selectedPluginState = selectedPlugin.getState(state);
+
     return (
       <SplitView>
         <SplitViewCol noPaddings>
@@ -31,7 +49,7 @@ export default connect(
         </SplitViewCol>
         <SplitViewCol grow sep>
           {selectedPluginState
-            ? <JSONTree data={selectedPluginState} />
+            ? <PluginState pluginState={selectedPluginState} />
             : <InfoPanel>Plugin doesn't have any state</InfoPanel>}
         </SplitViewCol>
       </SplitView>


### PR DESCRIPTION
Closes: #32

![prosemirror-dev-tools 2017-05-01 10-29-45](https://cloud.githubusercontent.com/assets/200119/25569350/1a6b28b4-2e59-11e7-90d0-5dfbed255e6e.png)
