### PR TITLE
build: add production env config for babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,10 @@
       }
     ],
     "react"
-  ]
+  ],
+  "env": {
+    "production": {
+      "presets": ["env", "react"]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"No tests yet\"",
     "start": "aik example/index.js -r",
     "build:umd": "webpack --optimize-minimize --config ./.build/webpack.config.umd.js",
-    "build:cjs": "babel src --out-dir dist/cjs",
+    "build:cjs": "BABEL_ENV=production babel src --out-dir dist/cjs",
     "lint:all": "eslint ./src",
     "lint:staged": "lint-staged",
     "preci:build": "rimraf ./dist",


### PR DESCRIPTION
Babel 7 has `.babelrc.js`. Life will be much easier 😄 