### PR TITLE
fix: unbreak package for all end users

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,17 +35,15 @@
     "ie-array-find-polyfill": "^1.1.0",
     "javascript-stringify": "^1.6.0",
     "jsondiffpatch": "github:d4rkr00t/jsondiffpatch#d80390b4354befe55802e292122b8059462c1b7d",
-    "prosemirror-model": ">=0.23.0",
-    "prosemirror-state": ">=0.23.0",
+    "prosemirror-model": "^1.0.0",
+    "prosemirror-state": "^1.0.0",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
     "react-dock": "^0.2.3",
     "react-json-tree": "^0.10.7",
     "react-syntax-highlighter": "^5.5.0",
     "react-tabs": "^1.1.0",
     "styled-components": "^2.1.0"
-  },
-  "peerDependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
   },
   "devDependencies": {
     "aik": "^0.16.1",
@@ -63,11 +61,9 @@
     "pmm": "^1.3.1",
     "pre-commit": "^1.2.2",
     "prettier": "^1.5.1",
-    "prosemirror-example-setup": "*",
-    "prosemirror-schema-basic": "*",
-    "prosemirror-view": "*",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
+    "prosemirror-example-setup": "^1.0.0",
+    "prosemirror-schema-basic": "^1.0.0",
+    "prosemirror-view": "^1.0.0",
     "rimraf": "^2.6.1",
     "webpack": "^2.4.1"
   },


### PR DESCRIPTION
Quick fix to #78 (as discussed in [this comment](https://github.com/d4rkr00t/prosemirror-dev-tools/issues/78#issuecomment-337987766)). This PR should unbreak the package for all users; package consumers are also no longer required to install react and react-dom themselves.

Tested in a project that uses React 16, and everything seems to work fine. (Though there are some warnings about proptypes.)