### PR TITLE
fix: bind dispatchTransaction

### DIFF
--- a/src/utils/subscribe-on-updates.js
+++ b/src/utils/subscribe-on-updates.js
@@ -1,6 +1,7 @@
 export default function subscribeOnUpdates(editorView, callback) {
-  const dispatch = editorView._props.dispatchTransaction ||
-    editorView.dispatch.bind(editorView);
+  const dispatch = (
+    editorView._props.dispatchTransaction || editorView.dispatch
+  ).bind(editorView);
 
   const handler = function(tr) {
     const oldState = editorView.state;


### PR DESCRIPTION
Bind `dispatchTransaction` so it is always called with the view instance as `this`.

Prosemirror always calls `dispatchTransaction` with the current view instance as `this`. 
https://github.com/ProseMirror/prosemirror-view/blob/master/src/index.js#L348
It's not happening when using dev-tools due to monkey-patching the `dispatchTransaction`. 
This PR fixes it.