### PR TITLE
Add methods to properly unmount the component & UNSAFE flag to componentWillReceiveProps

### DIFF
--- a/src/components/node-picker/index.js
+++ b/src/components/node-picker/index.js
@@ -31,7 +31,7 @@ class NodePicker extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.destroyEventHandlers();
 
     if (nextProps.nodePicker.active) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,25 +5,24 @@ import DevTools from "./dev-tools";
 import EditorStateContainer from "./state/editor";
 
 const DEVTOOLS_CLASS_NAME = "__prosemirror-dev-tools__";
+let containerElement = null;
 
-function createPlace() {
+function createOrFindPlace() {
   let place = document.querySelector(`.${DEVTOOLS_CLASS_NAME}`);
 
   if (!place) {
     place = document.createElement("div");
     place.className = DEVTOOLS_CLASS_NAME;
     document.body.appendChild(place);
-  } else {
-    ReactDOM.unmountComponentAtNode(place);
-    place.innerHTML = "";
   }
 
   return place;
 }
 
 function applyDevTools(editorView, props) {
-  const place = createPlace();
+  const place = createOrFindPlace();
   const editorState = new EditorStateContainer(editorView, props);
+  containerElement = place;
 
   ReactDOM.render(
     <Provider inject={[editorState]}>
@@ -31,7 +30,17 @@ function applyDevTools(editorView, props) {
     </Provider>,
     place
   );
+
+  return () => {
+    ReactDOM.unmountComponentAtNode(place);
+  };
+}
+
+function removeDevTools() {
+  if (containerElement) {
+    ReactDOM.unmountComponentAtNode(containerElement);
+  }
 }
 
 export default applyDevTools;
-export { applyDevTools };
+export { applyDevTools, removeDevTools };


### PR DESCRIPTION
So as stated in the title, this fixes the error messages where React complains that devTools has not been unmounted properly using ReactDOM.unmountComponentAtNode.

Basically with the current version this is never called properly and with this patch you can call it in a eg useEffect hook or such. Also this adds UNSAFE flag to componentWillReceiveProps which should stop React from complaining from using it. I guess it also prevents a bug in React 17 where they altogether remove those methods and only UNSAFE methods will work. A better idea would of course be to update the component to eg function component with hooks but I don't know if anyone has the time and willingness for that.