### PR TITLE
fix: 🐛 Update nanoid to 3.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "html": "^1.0.0",
     "jotai": "^1.10.0",
     "jsondiffpatch": "^0.4.1",
-    "nanoid": "^2.1.11",
+    "nanoid": "^3.3.8",
     "prosemirror-model": ">=1.0.0",
     "prosemirror-state": ">=1.0.0",
     "react-dock": "^0.6.0",

--- a/src/state/history.ts
+++ b/src/state/history.ts
@@ -1,7 +1,6 @@
 import { prettyPrint } from "html";
 import { atom } from "jotai";
-// @ts-expect-error package doesn't provide types
-import nanoid from "nanoid";
+import { nanoid } from "nanoid";
 import { DOMSerializer } from "prosemirror-model";
 import type { EditorState, Selection, Transaction } from "prosemirror-state";
 import type { JsonDiffMain } from "./json-diff-main";

--- a/src/state/json-diff-worker.ts
+++ b/src/state/json-diff-worker.ts
@@ -1,6 +1,5 @@
 import type { Delta } from "jsondiffpatch";
-// @ts-expect-error package doesn't provide types
-import nanoid from "nanoid";
+import { nanoid } from "nanoid";
 import { IdleScheduler } from "./idle-scheduler";
 
 export class JsonDiffWorker {


### PR DESCRIPTION
Hello! The current company I work at who uses this package has flagged that there is a vulnerability in nanoid, specifically:
```
nanoid (aka Nano ID) before 5.0.9 mishandles non-integer values. 3.3.8 is also a fixed version.
```

I've updated this package to the closest version possible with the fix in it. Hoping we can get this merged quickly so we can update this.